### PR TITLE
Better docker tags

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build_and_push_image:
@@ -20,7 +21,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: charlocharlie
+          username: mjmeli
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
@@ -36,7 +37,7 @@ jobs:
         with:
           push: true
           tags: |
-            charlocharlie/qbittorrent-port-forward-file:latest
+            mjmeli/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  packages: write
+
 jobs:
   build_and_push_image:
     name: Build Docker image and push to registries

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           push: true
           tags: |
-            mjmeli/${{ github.repository }}:latest
+            mjmeli/${{ github.event.repository.name }}:latest
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -41,6 +41,7 @@ jobs:
           push: true
           tags: |
             mjmeli/${{ github.event.repository.name }}:latest
+            mjmeli/${{ github.event.repository.name }}:${{ github.sha }}
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
 

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml
+  workflow_dispatch:
+
 jobs:
   dockerHubDescription:
     runs-on: ubuntu-latest
@@ -16,7 +18,7 @@ jobs:
     - name: Docker Hub Description
       uses: peter-evans/dockerhub-description@v2
       with:
-        username: charlocharlie
+        username: mjmeli
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        repository: charlocharlie/qbittorrent-port-forward-file
+        repository: mjmeli/qbittorrent-port-forward-gluetun-server
         readme-filepath: ./README.md

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -19,6 +19,6 @@ jobs:
       uses: peter-evans/dockerhub-description@v2
       with:
         username: mjmeli
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        repository: mjmeli/qbittorrent-port-forward-gluetun-server
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: mjmeli/${{ github.event.repository.name }}
         readme-filepath: ./README.md

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -21,4 +21,5 @@ jobs:
         username: mjmeli
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: mjmeli/${{ github.event.repository.name }}
+        short-description: ${{ github.event.repository.description }}
         readme-filepath: ./README.md

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,65 @@
+name: Build and push release image
+
+on:
+  release:
+    types: [created]
+  # workflow_dispatch allows manual triggering to backfill Docker images for existing releases
+  # Go to Actions > Build and push release image > Run workflow, then enter the tag name
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag name (e.g., v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  packages: write
+
+jobs:
+  build_and_push_release_image:
+    name: Build Docker image and push to registries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: mjmeli
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Determine tag name: use release tag when triggered by release event,
+      # otherwise use the tag_name input from workflow_dispatch (for backfilling)
+      - name: Set tag name
+        id: set_tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        id: docker_build_push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            mjmeli/${{ github.event.repository.name }}:${{ steps.set_tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:${{ steps.set_tag.outputs.tag }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_push.outputs.digest }}
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# qbittorrent-port-forward-file
+# qbittorrent-port-forward-gluetun-server
 
-A shell script and Docker container for automatically setting qBittorrent's listening port from a text file.
+A shell script and Docker container for automatically setting qBittorrent's listening port from Gluetun's control server.
 
 ## Config
 
@@ -11,35 +11,14 @@ A shell script and Docker container for automatically setting qBittorrent's list
 | QBT_USERNAME | `username`                  | `admin`                      | qBittorrent username                                            |
 | QBT_PASSWORD | `password`                  | `adminadmin`                 | qBittorrent password                                            |
 | QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
-| PORT_FILE    | `/config/my_file.txt`       | `/config/forwarded_port.txt` | Container path to the file containing the forwarded port number |
-
-### Volumes
-
-| Host location   | Container location | Mode | Description                                               |
-|-----------------|--------------------|------|-----------------------------------------------------------|
-| `/my/host/dir/` | `/config`          | `ro` | The directory in which the forwared ports file is located |
-
-## Context
-
-Made for use with [docker-wireguard-pia](https://github.com/thrnz/docker-wireguard-pia):
-
-* Environment variable: `PORT_FORWARDING=1`
-* Environment variable: `PORT_PERSIST=1`
-* Environment variable: `PORT_FILE=/pia/forwarded_port.txt`
-* Volume: `/my/host/dir:/pia:rw`
-
-Or for use with [gluetun](https://github.com/qdm12/gluetun):
-
-* Environment variable: `PRIVATE_INTERNET_ACCESS_VPN_PORT_FORWARDING=on`
-* Environment variable: `PRIVATE_INTERNET_ACCESS_VPN_PORT_FORWARDING_STATUS_FILE=/gluetun/forwarded_port.txt`
-* Volume: `/my/host/dir:/gluetun:rw`
+| GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
 
 ## Development
 
 ### Build Image
 
-`docker build . -t qbittorrent-port-forwarder`
+`docker build . -t qbittorrent-port-forward-gluetun-server`
 
 ### Run Container
 
-`docker run --rm -it -e QBT_ADDR=http://192.168.1.100:8080 -v $(pwd)/config:/config qbittorrent-port-forwarder:latest`
+`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 qbittorrent-port-forward-gluetun-server:latest`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ A shell script and Docker container for automatically setting qBittorrent's list
 | QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
 | GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
 
+## Example
+
+### Docker-Compose
+
+The following is an example docker-compose:
+
+```yaml
+  qbittorrent-port-forward-gluetun-server:
+    image: mjmeli/qbittorrent-port-forward-gluetun-server
+    container_name: qbittorrent-port-forward-gluetun-server
+    restart: unless-stopped
+    environment:
+      - QBT_USERNAME=username
+      - QBT_PASSWORD=password
+      - QBT_ADDR=http://192.168.1.100:8080
+      - GTN_ADDR=http://192.168.1.100:8000
+```
+
 ## Development
 
 ### Build Image

--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ A shell script and Docker container for automatically setting qBittorrent's list
 
 
 ## Gluetun Control Server Authentication
-1. Generate api key using the following command: `docker run --rm qmcgaw/gluetun genkey`
-2. Create a new file on your Gluetun host system with the following contents:
-```toml# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
+1. Create a new file on your Gluetun host system with the following contents:
+```toml
+# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
 [[roles]]
 name = "qbittorrent"
 # Define a list of routes with the syntax "Http-Method /path"
 routes = ["GET /v1/openvpn/portforwarded"]
 # Define an authentication method with its parameters
 auth = "apikey"
-apikey = "CHANGEME" # generate using "docker run --rm qmcgaw/gluetun genkey"
+apikey = "CHANGEME" # can be generated using "docker run --rm qmcgaw/gluetun genkey"
 ```
-3. Bind mount the file you created to `/gluetun/auth/config.toml`.
+3. Bind mount the file you created to `/gluetun/auth/config.toml` in your gluetun docker instance.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ A shell script and Docker container for automatically setting qBittorrent's list
 | QBT_PASSWORD | `password`                  | `adminadmin`                 | qBittorrent password                                            |
 | QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
 | GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
+| GTN_APIKEY   | `apikey`                    | `CHANGEME`                   | API Key for communication to gluetun control server             |
+
+
+## Gluetun Control Server Authentication
+1. Generate api key using the following command: `docker run --rm qmcgaw/gluetun genkey`
+2. Create a new file on your Gluetun host system with the following contents:
+```toml# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
+[[roles]]
+name = "qbittorrent"
+# Define a list of routes with the syntax "Http-Method /path"
+routes = ["GET /v1/openvpn/portforwarded"]
+# Define an authentication method with its parameters
+auth = "apikey"
+apikey = "CHANGEME" # generate using "docker run --rm qmcgaw/gluetun genkey"
+```
+3. Bind mount the file you created to `/gluetun/auth/config.toml`.
 
 ## Example
 
@@ -29,6 +45,7 @@ The following is an example docker-compose:
       - QBT_PASSWORD=password
       - QBT_ADDR=http://192.168.1.100:8080
       - GTN_ADDR=http://192.168.1.100:8000
+      - GTN_APIKEY=apikey
 ```
 
 ## Development
@@ -39,4 +56,4 @@ The following is an example docker-compose:
 
 ### Run Container
 
-`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 qbittorrent-port-forward-gluetun-server:latest`
+`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 -e GTN_APIKEY=CHANGEME qbittorrent-port-forward-gluetun-server:latest`

--- a/README.md
+++ b/README.md
@@ -6,28 +6,26 @@ A shell script and Docker container for automatically setting qBittorrent's list
 
 ### Environment Variables
 
-| Variable     | Example                     | Default                      | Description                                                     |
-|--------------|-----------------------------|------------------------------|-----------------------------------------------------------------|
-| QBT_USERNAME | `username`                  | `admin`                      | qBittorrent username                                            |
-| QBT_PASSWORD | `password`                  | `adminadmin`                 | qBittorrent password                                            |
-| QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
-| GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
-| GTN_APIKEY   | `apikey`                    | `CHANGEME`                   | API Key for communication to gluetun control server             |
+| Variable     | Example                     | Default                 | Description                                                                    |
+|--------------|-----------------------------|-------------------------|--------------------------------------------------------------------------------|
+| QBT_USERNAME | `username`                  | `admin`                 | qBittorrent username                                                           |
+| QBT_PASSWORD | `password`                  | `adminadmin`            | qBittorrent password                                                           |
+| QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080` | HTTP URL for the qBittorrent web UI, with port                                 |
+| GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000` | HTTP URL for the gluetun control server, with port                             |
+| GTN_USERNAME | `username`                  | *None*                  | Username for authentication to gluetun control server (if basic auth enabled)  |
+| GTN_PASSWORD | `password`                  | *None*                  | Password for authentication to gluetun control server (if basic auth enabled)  |
+| GTN_APIKEY   | `apikey`                    | *None*                  | API Key for authentication to gluetun control server (if API key auth enabled) |
 
 
 ## Gluetun Control Server Authentication
-1. Create a new file on your Gluetun host system with the following contents:
-```toml
-# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
-[[roles]]
-name = "qbittorrent"
-# Define a list of routes with the syntax "Http-Method /path"
-routes = ["GET /v1/openvpn/portforwarded"]
-# Define an authentication method with its parameters
-auth = "apikey"
-apikey = "CHANGEME" # can be generated using "docker run --rm qmcgaw/gluetun genkey"
-```
-3. Bind mount the file you created to `/gluetun/auth/config.toml` in your gluetun docker instance.
+Starting in Gluetun v3.4, it is required to setup authentication on the Gluetun control server routes.
+
+See this link for information on how to set this up: https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication
+
+Once configured in Gluetun, you can configure this container to use the appropriate authentication method:
+- If using `none` auth, you do not need to provide any of the authentication environment variables
+- If using `basic` auth, you should set the `GTN_USERNAME` and `GTN_PASSWORD` environment variables
+- If using `apikey` auth, you should set the `GTN_APIKEY` environment variable
 
 ## Example
 
@@ -45,15 +43,17 @@ The following is an example docker-compose:
       - QBT_PASSWORD=password
       - QBT_ADDR=http://192.168.1.100:8080
       - GTN_ADDR=http://192.168.1.100:8000
-      - GTN_APIKEY=apikey
+      - GTN_APIKEY=CHANGEME
 ```
 
 ## Development
 
 ### Build Image
-
-`docker build . -t qbittorrent-port-forward-gluetun-server`
+```bash
+docker build . -t qbittorrent-port-forward-gluetun-server
+```
 
 ### Run Container
-
-`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 -e GTN_APIKEY=CHANGEME qbittorrent-port-forward-gluetun-server:latest`
+```bash
+docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 -e GTN_APIKEY=CHANGEME qbittorrent-port-forward-gluetun-server:latest
+```

--- a/main.sh
+++ b/main.sh
@@ -4,14 +4,9 @@ set -e
 qbt_username="${QBT_USERNAME:-admin}"
 qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
-port_file="${PORT_FILE:-/config/forwarded_port.txt}" # ex. /config/forwarded_port.txt
+gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
-if [ ! -e "$port_file" ]; then
-    echo "Port file $port_file does not exist"
-    exit 1
-fi
-
-port_number=$(cat $port_file)
+port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
 
 curl --fail --silent --show-error --cookie-jar /tmp/cookies.txt --cookie /tmp/cookies.txt --header "Referer: $qbt_addr" --data "username=$qbt_username" --data "password=$qbt_password" $qbt_addr/api/v2/auth/login 1> /dev/null
 

--- a/main.sh
+++ b/main.sh
@@ -7,7 +7,7 @@ qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
 port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
-if [ ! "$port_number" ]; then
+if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1
 fi

--- a/main.sh
+++ b/main.sh
@@ -7,6 +7,10 @@ qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
 port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+if [ ! "$port_number" ]; then
+    echo "Could not get current forwarded port from gluetun, exiting..."
+    exit 1
+fi
 
 curl --fail --silent --show-error --cookie-jar /tmp/cookies.txt --cookie /tmp/cookies.txt --header "Referer: $qbt_addr" --data "username=$qbt_username" --data "password=$qbt_password" $qbt_addr/api/v2/auth/login 1> /dev/null
 

--- a/main.sh
+++ b/main.sh
@@ -8,13 +8,13 @@ gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
 if [[ -n "$GTN_USERNAME" && -n "$GTN_PASSWORD" ]]; then
     echo "Attempting to retrieve port from Gluetun via username and password..."
-    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/portforward | jq '.port')
 elif [ -n "$GTN_APIKEY" ]; then
     echo "Attempting to retrieve port from Gluetun via api key..."
-    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/portforward | jq '.port')
 else
     echo "Attempting to retrieve port from Gluetun without authentication..."
-    port_number=$(curl --fail --silent --show-error  $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+    port_number=$(curl --fail --silent --show-error  $gtn_addr/v1/portforward | jq '.port')
 fi
 
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then

--- a/main.sh
+++ b/main.sh
@@ -6,7 +6,7 @@ qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
-port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+port_number=$(curl --fail --silent --show-error  $gtn_addr/v1/openvpn/portforwarded | jq '.port')
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1

--- a/main.sh
+++ b/main.sh
@@ -5,8 +5,9 @@ qbt_username="${QBT_USERNAME:-admin}"
 qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
+gtn_apikey="${GTN_APIKEY:-CHANGEME}"
 
-port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1

--- a/main.sh
+++ b/main.sh
@@ -6,7 +6,7 @@ qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
-port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1

--- a/main.sh
+++ b/main.sh
@@ -5,12 +5,23 @@ qbt_username="${QBT_USERNAME:-admin}"
 qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
-gtn_apikey="${GTN_APIKEY:-CHANGEME}"
 
-port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+if [[ -n "$GTN_USERNAME" && -n "$GTN_PASSWORD" ]]; then
+    echo "Attempting to retrieve port from Gluetun via username and password..."
+    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+elif [ -n "$GTN_APIKEY" ]; then
+    echo "Attempting to retrieve port from Gluetun via api key..."
+    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+else
+    echo "Attempting to retrieve port from Gluetun without authentication..."
+    port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+fi
+
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1
+else
+    echo "Port number succesfully retrieved from Gluetun: $port_number"
 fi
 
 curl --fail --silent --show-error --cookie-jar /tmp/cookies.txt --cookie /tmp/cookies.txt --header "Referer: $qbt_addr" --data "username=$qbt_username" --data "password=$qbt_password" $qbt_addr/api/v2/auth/login 1> /dev/null


### PR DESCRIPTION
This pull request introduces significant updates to transition the project from using a static port file to dynamically retrieving the forwarded port from the Gluetun control server, including support for multiple authentication methods. It also renames the project and updates Docker publishing workflows to use a new DockerHub username and repository naming convention. The most important changes are grouped below:

**Major functionality and project changes:**

* The project now retrieves the forwarded port directly from the Gluetun control server API, supporting unauthenticated, basic auth, and API key authentication methods in `main.sh`. The old file-based port retrieval method is removed.
* The project is renamed from `qbittorrent-port-forward-file` to `qbittorrent-port-forward-gluetun-server`, with all related documentation, environment variables, and usage examples updated in `README.md`.

**DockerHub and CI/CD workflow updates:**

* All GitHub Actions workflows are updated to use the new DockerHub username (`mjmeli`) and repository naming convention based on the repository name, instead of the previous static values. This includes updates to login credentials, image tags, and repository references in `.github/workflows/build-and-push-image.yml` and `.github/workflows/dockerhub-description.yml`. [[1]](diffhunk://#diff-c7cbc4a36f236b91dd212d03b3a15dd7ea80de2a647ac34aeec2ba9bf70f8fc4L23-R27) [[2]](diffhunk://#diff-c7cbc4a36f236b91dd212d03b3a15dd7ea80de2a647ac34aeec2ba9bf70f8fc4L39-R44) [[3]](diffhunk://#diff-3d4af89932c6c3fa49ebe3a759ce38d5468c49450ad83f7bedd300b114b2402fL19-R24)
* Manual workflow dispatch is enabled for both build/push and DockerHub description workflows to allow manual triggering from the GitHub Actions UI. [[1]](diffhunk://#diff-c7cbc4a36f236b91dd212d03b3a15dd7ea80de2a647ac34aeec2ba9bf70f8fc4R7-R10) [[2]](diffhunk://#diff-3d4af89932c6c3fa49ebe3a759ce38d5468c49450ad83f7bedd300b114b2402fR10-R11)
* A new workflow `.github/workflows/release-image.yml` is added to build and push Docker images for GitHub release tags, supporting both automatic and manual (backfill) triggers.